### PR TITLE
Update beta warning to improve accuracy

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -5,8 +5,7 @@ owner: Fleet Management
 
 <strong><%= modified_date %></strong>
 
-<p class="note warning"><strong>Warning:</strong> Service Instance Manager for PCF is currently in beta and is
-   intended for evaluation and test purposes only.
+<p class="note warning"><strong>Warning:</strong> Service Instance Manager for PCF is currently in beta and may not continue to be supported in the future.
 </p>
 
 This documentation describes the Service Instance Manager for Pivotal Cloud Foundry (PCF).


### PR DESCRIPTION
The previous warning suggested that we don't recommend using SIM in production which is not the case.
The beta classification implies that it might not continue to be supported in the future.